### PR TITLE
Add guard and budget constraints to adapter promotion

### DIFF
--- a/Lemniscata/configs/default.yaml
+++ b/Lemniscata/configs/default.yaml
@@ -20,6 +20,13 @@ adapters:
   shadow_window: 200
   canary_traffic: 0.05
   promotion_thresholds:
-    ece: 0.05
-    latency_p95_ms: 1500
     cost_per_1k: 0.02
+guards:
+  lyapunov_deriv_max: 0.0
+  oci_minimum: 0.8
+  ece_limit: 0.05
+  latency_p95_ms: 1500
+budgets:
+  gpu_memory_gb: 24
+  token_usage: 1000000
+  hourly_cost: 5.0

--- a/Lemniscata/src/lemnisiana/adapters/gating.py
+++ b/Lemniscata/src/lemnisiana/adapters/gating.py
@@ -6,8 +6,20 @@ class AdapterMetrics:
     ece: float
     latency_p95_ms: float
     cost_per_1k: float
+    lyapunov_deriv: float = 0.0
+    oci: float = 1.0
+    gpu_mem_gb: float = 0.0
+    token_usage: int = 0
+    hourly_cost: float = 0.0
 
-def allow_promotion(m: AdapterMetrics, thr: dict) -> bool:
-    return (m.ece <= thr.get('ece', 0.05) and
-            m.latency_p95_ms <= thr.get('latency_p95_ms', 1500) and
-            m.cost_per_1k <= thr.get('cost_per_1k', 0.05))
+def allow_promotion(m: AdapterMetrics, thr: dict, guards: dict, budgets: dict) -> bool:
+    return (
+        m.cost_per_1k <= thr.get('cost_per_1k', 0.05) and
+        m.ece <= guards.get('ece_limit', 0.05) and
+        m.latency_p95_ms <= guards.get('latency_p95_ms', 1500) and
+        m.lyapunov_deriv <= guards.get('lyapunov_deriv_max', 0.0) and
+        m.oci >= guards.get('oci_minimum', 0.0) and
+        m.gpu_mem_gb <= budgets.get('gpu_memory_gb', float('inf')) and
+        m.token_usage <= budgets.get('token_usage', float('inf')) and
+        m.hourly_cost <= budgets.get('hourly_cost', float('inf'))
+    )

--- a/Lemniscata/src/lemnisiana/adapters/promoter.py
+++ b/Lemniscata/src/lemnisiana/adapters/promoter.py
@@ -2,12 +2,18 @@ from __future__ import annotations
 import json, os
 from .gating import AdapterMetrics, allow_promotion
 
-def decide_promotion(shadow_metrics_path: str, canary_metrics_path: str, thresholds: dict) -> dict:
+def decide_promotion(
+    shadow_metrics_path: str,
+    canary_metrics_path: str,
+    thresholds: dict,
+    guards: dict,
+    budgets: dict,
+) -> dict:
     if not (os.path.exists(shadow_metrics_path) and os.path.exists(canary_metrics_path)):
         return {"promote": False, "reason": "missing_metrics"}
     s = json.load(open(shadow_metrics_path))
     c = json.load(open(canary_metrics_path))
     # require shadow pass and canary stable
-    s_ok = allow_promotion(AdapterMetrics(**s), thresholds)
-    c_ok = allow_promotion(AdapterMetrics(**c), thresholds)
+    s_ok = allow_promotion(AdapterMetrics(**s), thresholds, guards, budgets)
+    c_ok = allow_promotion(AdapterMetrics(**c), thresholds, guards, budgets)
     return {"promote": bool(s_ok and c_ok), "shadow_ok": s_ok, "canary_ok": c_ok}


### PR DESCRIPTION
## Summary
- add `guards` settings for Lyapunov derivative, OCI minimums, and ECE/latency limits
- introduce `budgets` for GPU memory, tokens, and hourly cost
- enforce new guard and budget checks in promotion gating

## Testing
- `PYTHONPATH=src pytest tests/test_smoke.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a68b4073a8833385802ee70598ad60