### PR TITLE
Add comprehensive test suite for Lemniscata modules

### DIFF
--- a/Lemniscata/tests/chaos/test_chaos.py
+++ b/Lemniscata/tests/chaos/test_chaos.py
@@ -1,0 +1,11 @@
+import pytest
+from lemnisiana.legacy_core.iaaa_integrated_system import IAAAConfig, IntegratedIAAASystem
+
+
+@pytest.mark.skip(reason="Chaos test scaffold - enable to simulate fault tolerance scenarios")
+def test_chaos_component_failure():
+    config = IAAAConfig()
+    system = IntegratedIAAASystem(config)
+    # Simulate component failure by removing EDNAG
+    system.components.pop("ednag")
+    system.evolve(num_cycles=1)

--- a/Lemniscata/tests/e2e/test_full_loop.py
+++ b/Lemniscata/tests/e2e/test_full_loop.py
@@ -1,0 +1,10 @@
+from lemnisiana.legacy_core.iaaa_integrated_system import IAAAConfig, IntegratedIAAASystem
+
+
+def test_full_lemniscata_loop_one_cycle():
+    config = IAAAConfig(ednag_population_size=3, max_evolution_cycles=1)
+    system = IntegratedIAAASystem(config)
+    results = system.evolve(num_cycles=1)
+    assert results["cycles_completed"] == 1
+    assert "final_performance" in results
+    assert isinstance(results["evolution_trajectory"], list)

--- a/Lemniscata/tests/integration/test_ednag_backpropamine.py
+++ b/Lemniscata/tests/integration/test_ednag_backpropamine.py
@@ -1,0 +1,8 @@
+from lemnisiana.legacy_core.iaaa_integrated_system import IAAAConfig, IntegratedIAAASystem
+
+
+def test_interaction_ednag_to_backpropamine_exists():
+    config = IAAAConfig()
+    system = IntegratedIAAASystem(config)
+    interactions = system.component_interactions["ednag"]
+    assert any(interaction["target"] == "backpropamine" for interaction in interactions)

--- a/Lemniscata/tests/soak/test_soak.py
+++ b/Lemniscata/tests/soak/test_soak.py
@@ -1,0 +1,9 @@
+import pytest
+from lemnisiana.legacy_core.iaaa_integrated_system import IAAAConfig, IntegratedIAAASystem
+
+
+@pytest.mark.skip(reason="Soak test scaffold - enable for long-running stability tests")
+def test_soak_runs_multiple_cycles():
+    config = IAAAConfig(max_evolution_cycles=100, ednag_population_size=10)
+    system = IntegratedIAAASystem(config)
+    system.evolve(num_cycles=100)

--- a/Lemniscata/tests/unit/test_backpropamine.py
+++ b/Lemniscata/tests/unit/test_backpropamine.py
@@ -1,0 +1,14 @@
+from lemnisiana.legacy_core.iaaa_integrated_system import IAAAConfig, IntegratedIAAASystem
+
+
+def test_backpropamine_initialization_and_history():
+    config = IAAAConfig(initial_learning_rate=0.005, adaptation_strength=0.2)
+    system = IntegratedIAAASystem(config)
+    bp = system.components.get("backpropamine")
+    assert bp["type"] == "backpropamine"
+    assert bp["learning_rate"] == 0.005
+    assert bp["adaptation_strength"] == 0.2
+    # simulate gradients to update history
+    bp["gradient_history"].extend([0.1, -0.2, 0.05])
+    system._update_backpropamine(bp)
+    assert bp["learning_rate_history"]

--- a/Lemniscata/tests/unit/test_ednag.py
+++ b/Lemniscata/tests/unit/test_ednag.py
@@ -1,0 +1,15 @@
+import numpy as np
+from lemnisiana.legacy_core.iaaa_integrated_system import IAAAConfig, IntegratedIAAASystem
+
+
+def test_ednag_initialization_population_and_rates():
+    config = IAAAConfig(ednag_population_size=4, ednag_mutation_rate=0.2, ednag_crossover_rate=0.7)
+    system = IntegratedIAAASystem(config)
+    ednag = system.components.get("ednag")
+    assert ednag["type"] == "ednag"
+    assert len(ednag["population"]) == 4
+    assert ednag["mutation_rate"] == 0.2
+    assert ednag["crossover_rate"] == 0.7
+    # ensure each individual has required keys
+    for individual in ednag["population"]:
+        assert set(individual.keys()) >= {"id", "genome", "phenotype"}


### PR DESCRIPTION
## Summary
- Add EDNAG unit tests covering population setup and mutation parameters
- Add Backpropamine unit tests and interactions between EDNAG and Backpropamine
- Add end-to-end Lemniscata loop test plus soak and chaos test scaffolds

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a68b411f788333aab6c865fc283112