### PR TITLE
Add adapter stubs for experimental packages

### DIFF
--- a/Lemniscata/src/lemnisiana/__init__.py
+++ b/Lemniscata/src/lemnisiana/__init__.py
@@ -1,1 +1,10 @@
-__all__ = []
+from . import ednag, backpropamine, rdis, autopoietic, quantum
+
+__all__ = [
+    "ednag",
+    "backpropamine",
+    "rdis",
+    "autopoietic",
+    "quantum",
+]
+

--- a/Lemniscata/src/lemnisiana/autopoietic/__init__.py
+++ b/Lemniscata/src/lemnisiana/autopoietic/__init__.py
@@ -1,0 +1,24 @@
+"""Adapter for autopoietic neural network experiments."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+@dataclass
+class AutopoieticNetwork:
+    """Expose an autopoietic network through a simple interface."""
+
+    backend: Callable[..., Any] | None = None
+
+    def evolve(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate evolution to the backend."""
+
+        if self.backend is None:
+            raise RuntimeError("Autopoietic backend is not available")
+        return self.backend(*args, **kwargs)
+
+
+__all__ = ["AutopoieticNetwork"]
+

--- a/Lemniscata/src/lemnisiana/backpropamine/__init__.py
+++ b/Lemniscata/src/lemnisiana/backpropamine/__init__.py
@@ -1,0 +1,28 @@
+"""Adapter for the Backpropamine neuromodulated network project."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+@dataclass
+class NeuromodulatedNetwork:
+    """Thin wrapper around a neuromodulated network backend.
+
+    The heavy Backpropamine dependency is optional; a custom ``backend``
+    callable implementing the update logic can be supplied instead.
+    """
+
+    backend: Callable[..., Any] | None = None
+
+    def step(self, *args: Any, **kwargs: Any) -> Any:
+        """Run a single update step via the backend."""
+
+        if self.backend is None:
+            raise RuntimeError("Backpropamine backend is not available")
+        return self.backend(*args, **kwargs)
+
+
+__all__ = ["NeuromodulatedNetwork"]
+

--- a/Lemniscata/src/lemnisiana/ednag/__init__.py
+++ b/Lemniscata/src/lemnisiana/ednag/__init__.py
@@ -1,0 +1,33 @@
+"""Adapters for the EDNAG neural architecture search project.
+
+This module provides a light-weight wrapper so that importing
+``lemnisiana.ednag`` does not require the heavy EDNAG dependency.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+@dataclass
+class ArchitectureGenerator:
+    """Minimal adapter exposing an EDNAG style generator.
+
+    The real EDNAG project is optional; users can pass in a custom
+    ``backend`` callable implementing the generation logic. This keeps
+    the dependency optional while offering a uniform interface.
+    """
+
+    backend: Callable[..., Any] | None = None
+
+    def generate(self, *args: Any, **kwargs: Any) -> Any:
+        """Delegate to the underlying backend if available."""
+
+        if self.backend is None:
+            raise RuntimeError("EDNAG backend is not available")
+        return self.backend(*args, **kwargs)
+
+
+__all__ = ["ArchitectureGenerator"]
+

--- a/Lemniscata/src/lemnisiana/quantum/__init__.py
+++ b/Lemniscata/src/lemnisiana/quantum/__init__.py
@@ -1,0 +1,24 @@
+"""Adapter for quantum inspired agents."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+@dataclass
+class QuantumCircuit:
+    """Minimal wrapper around a quantum style backend."""
+
+    backend: Callable[..., Any] | None = None
+
+    def run(self, *args: Any, **kwargs: Any) -> Any:
+        """Run the circuit via the backend."""
+
+        if self.backend is None:
+            raise RuntimeError("Quantum backend is not available")
+        return self.backend(*args, **kwargs)
+
+
+__all__ = ["QuantumCircuit"]
+

--- a/Lemniscata/src/lemnisiana/rdis/__init__.py
+++ b/Lemniscata/src/lemnisiana/rdis/__init__.py
@@ -1,0 +1,28 @@
+"""Adapter for the RDIS project."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+@dataclass
+class RDISPipeline:
+    """Wrapper around an RDIS processing pipeline.
+
+    Users may supply a ``backend`` callable that performs the actual
+    computation, keeping the RDIS dependency optional.
+    """
+
+    backend: Callable[..., Any] | None = None
+
+    def run(self, *args: Any, **kwargs: Any) -> Any:
+        """Execute the pipeline via the backend."""
+
+        if self.backend is None:
+            raise RuntimeError("RDIS backend is not available")
+        return self.backend(*args, **kwargs)
+
+
+__all__ = ["RDISPipeline"]
+

--- a/Lemniscata/tests/test_smoke.py
+++ b/Lemniscata/tests/test_smoke.py
@@ -1,2 +1,14 @@
 def test_import():
     import lemnisiana
+
+    from lemnisiana.ednag import ArchitectureGenerator
+    from lemnisiana.backpropamine import NeuromodulatedNetwork
+    from lemnisiana.rdis import RDISPipeline
+    from lemnisiana.autopoietic import AutopoieticNetwork
+    from lemnisiana.quantum import QuantumCircuit
+
+    assert ArchitectureGenerator
+    assert NeuromodulatedNetwork
+    assert RDISPipeline
+    assert AutopoieticNetwork
+    assert QuantumCircuit


### PR DESCRIPTION
## Summary
- add optional adapters for EDNAG, Backpropamine, RDIS, Autopoietic nets, and quantum agents
- expose new subpackages via lemnisiana package init
- extend smoke test to validate imports of new adapters

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=Lemniscata/src pytest Lemniscata/tests/test_smoke.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a68b3dfffc8333a1f51e4e5950210b