### PR TITLE
Add autopoietic metrics and Lyapunov orchestrator

### DIFF
--- a/autopoietic/__init__.py
+++ b/autopoietic/__init__.py
@@ -1,0 +1,14 @@
+"""Autopoietic metrics and orchestration utilities."""
+
+from .metrics import MaintenanceIndicators, compute_indicators, compute_oci
+from .lyapunov import V, vdot
+from .orchestrator import AutopoieticOrchestrator
+
+__all__ = [
+    "MaintenanceIndicators",
+    "compute_indicators",
+    "compute_oci",
+    "V",
+    "vdot",
+    "AutopoieticOrchestrator",
+]

--- a/autopoietic/lyapunov.py
+++ b/autopoietic/lyapunov.py
@@ -1,0 +1,14 @@
+def V(x: float) -> float:
+    """Simple Lyapunov function.
+
+    Uses V(x) = 0.5 * x^2 which is positive definite.
+    """
+    return 0.5 * x ** 2
+
+
+def vdot(x: float, dx_dt: float) -> float:
+    """Time derivative of ``V``.
+
+    For V(x) = 0.5*x^2, the derivative is x * dx/dt.
+    """
+    return x * dx_dt

--- a/autopoietic/metrics.py
+++ b/autopoietic/metrics.py
@@ -1,0 +1,54 @@
+from dataclasses import dataclass
+import numpy as np
+
+
+@dataclass
+class MaintenanceIndicators:
+    """Container for maintenance indicators.
+
+    Parameters
+    ----------
+    production: float
+        Average production value.
+    decay: float
+        Average decay value.
+    maintenance: float
+        Average maintenance value.
+    consumption: float
+        Average consumption value.
+    """
+
+    production: float
+    decay: float
+    maintenance: float
+    consumption: float
+
+
+def compute_indicators(history: np.ndarray) -> MaintenanceIndicators:
+    """Compute maintenance indicators from a history matrix.
+
+    The ``history`` array must have four columns representing
+    Production, Decay, Maintenance and Consumption values respectively.
+    The function returns the mean value for each indicator.
+    """
+    history = np.asarray(history)
+    if history.ndim != 2 or history.shape[1] != 4:
+        raise ValueError("history must be a 2D array with 4 columns")
+
+    prod = float(np.mean(history[:, 0]))
+    decay = float(np.mean(history[:, 1]))
+    maint = float(np.mean(history[:, 2]))
+    cons = float(np.mean(history[:, 3]))
+    return MaintenanceIndicators(prod, decay, maint, cons)
+
+
+def compute_oci(indicators: MaintenanceIndicators) -> float:
+    """Compute the Organizational Complexity Index (OCI).
+
+    OCI is defined as (production + maintenance) / (decay + consumption).
+    The denominator is clamped to a small value to avoid division by zero.
+    """
+    denom = indicators.decay + indicators.consumption
+    if abs(denom) < 1e-9:
+        denom = 1e-9
+    return (indicators.production + indicators.maintenance) / denom

--- a/autopoietic/orchestrator.py
+++ b/autopoietic/orchestrator.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from prometheus_client import Gauge, start_http_server
+
+from .metrics import compute_indicators, compute_oci
+from .lyapunov import vdot
+
+
+class AutopoieticOrchestrator:
+    """Simple orchestrator managing mutation/learning rates.
+
+    It evaluates OCI and the Lyapunov derivative ``vdot`` for a given
+    window of data. The values are exported as Prometheus metrics and
+    the rates are adjusted based on the sign of ``vdot``.
+    """
+
+    def __init__(
+        self,
+        mutation_rate: float = 0.01,
+        learning_rate: float = 0.01,
+        port: int | None = 8000,
+        start_server: bool = True,
+    ) -> None:
+        self.mutation_rate = mutation_rate
+        self.learning_rate = learning_rate
+        self.last_oci = 0.0
+        self.last_vdot = 0.0
+
+        self.oci_gauge = Gauge("oci", "Organizational Complexity Index")
+        self.vdot_gauge = Gauge("vdot", "Derivative of Lyapunov function")
+
+        if start_server and port is not None:
+            start_http_server(port)
+
+    # ------------------------------------------------------------------
+    def step(self, history, state: float, dstate_dt: float) -> None:
+        """Process a new window of history and update metrics."""
+        indicators = compute_indicators(history)
+        self.last_oci = compute_oci(indicators)
+        self.oci_gauge.set(self.last_oci)
+
+        self.last_vdot = vdot(state, dstate_dt)
+        self.vdot_gauge.set(self.last_vdot)
+
+        self._adjust_rates()
+
+    # ------------------------------------------------------------------
+    def _adjust_rates(self) -> None:
+        """Adjust mutation and learning rates based on ``vdot``."""
+        factor = 1.1 if self.last_vdot > 0 else 0.9
+        self.mutation_rate *= factor
+        self.learning_rate *= factor
+
+    # ------------------------------------------------------------------
+    def check_promotion(self, oci_threshold: float, vdot_threshold: float = 0.0) -> bool:
+        """Check promotion gate conditions.
+
+        Promotion is granted only if OCI exceeds ``oci_threshold`` and
+        the system is stable (``vdot`` below ``vdot_threshold``).
+        """
+        return self.last_oci >= oci_threshold and self.last_vdot <= vdot_threshold

--- a/autopoietic/tests/test_autopoietic.py
+++ b/autopoietic/tests/test_autopoietic.py
@@ -1,0 +1,38 @@
+import numpy as np
+
+from autopoietic.metrics import compute_indicators, compute_oci
+from autopoietic.orchestrator import AutopoieticOrchestrator
+from autopoietic.lyapunov import V, vdot
+
+
+def test_compute_indicators_and_oci():
+    history = np.array([
+        [10, 2, 3, 1],
+        [8, 3, 4, 2],
+    ])
+    indicators = compute_indicators(history)
+    assert indicators.production == 9.0
+    assert indicators.decay == 2.5
+    assert indicators.maintenance == 3.5
+    assert indicators.consumption == 1.5
+    oci = compute_oci(indicators)
+    assert oci == (9.0 + 3.5) / (2.5 + 1.5)
+
+
+def test_orchestrator_step_and_promotion():
+    history = np.array([[10, 2, 3, 1]])
+    orch = AutopoieticOrchestrator(start_server=False)
+    orch.step(history, state=1.0, dstate_dt=-0.1)
+    # vdot should be negative indicating stability
+    assert orch.last_vdot == -0.1
+    # mutation rate should decrease due to negative vdot
+    assert orch.mutation_rate < 0.01
+    # OCI should be large enough for promotion
+    assert orch.check_promotion(oci_threshold=1.0)
+
+
+def test_lyapunov_functions():
+    x = 2.0
+    dx = -0.5
+    assert V(x) == 2.0
+    assert vdot(x, dx) == -1.0


### PR DESCRIPTION
## Summary
- add `autopoietic` module with OCI and maintenance metrics
- integrate Lyapunov-based orchestrator adjusting mutation and learning rates
- expose OCI and `vdot` as Prometheus metrics and add promotion gate check

## Testing
- `PYTHONPATH=. PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest autopoietic/tests/test_autopoietic.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a69164fae08333895c04d3f96cc153