### PR TITLE
Add whitepaper aggregation and PDF build script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: docs
+
+docs:
+	bash scripts/build_pdf.sh

--- a/docs/whitepaper.md
+++ b/docs/whitepaper.md
@@ -1,0 +1,55 @@
+# Lemniscata de Penin Whitepaper
+
+This document consolidates project information from various sources.
+
+## megaIAAA Overview
+
+megaIAAA is a collection of AI research projects.
+
+## Lemnisiana IAAA — R33 All‑in‑One
+
+**Plug‑and‑play** package that wires R‑Zero on‑policy with multi‑metric self‑consistency, TTD‑DR with active retrieval, Dual‑Verifier (LLM grader + heuristics), adapters (LoRA/FT) with **shadow→canary→promotion** gates, full benchmarks (GSM8K/MMLU/MBPP loaders), calibration (ECE) and a Prometheus/Grafana‑ready dashboard.
+
+### Quickstart
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt
+pip install -e .  # editable
+export OPENAI_API_KEY=sk-...
+# Optional: set LLM provider (stub|openai|ollama)
+export LEM_PROVIDER=openai
+# Launch dashboard (http://localhost:8000)
+lemnisiana-dashboard
+```
+
+### Run R‑Zero on‑policy (self-consistency maj@k)
+```bash
+lemnisiana-rzero --maj_k 7 --samples 8 --verifier real --dataset ./datasets/gsm8k/train.jsonl
+```
+
+### Run TTD‑DR with active retrieval
+```bash
+lemnisiana-ttddr --corpus ./corpus --steps 12 --emit report.md
+```
+
+### Train LoRA adapter from fail‑cases (auto‑curriculum)
+```bash
+lemnisiana-train-lora --failures ./artifacts/failures.jsonl --base_model Qwen2.5-3B
+```
+
+Security tips: run canaries with CPU/mem quotas and a seccomp profile:
+```bash
+docker run --rm -p 8000:8000   --cpus="2" --memory="4g"   --security-opt seccomp=./docker/seccomp-profile.json   lemnisiana:latest
+```
+
+## Module Notes
+
+### adapters/gating.py
+Adapter promotion gating based on ECE, latency, and cost thresholds.
+
+### adapters/promoter.py
+Decides promotion using metrics from shadow and canary runs.
+
+### rzero/on_policy.py
+On-policy R-Zero with multi-metric self-consistency, dual verification, and calibration logging.

--- a/scripts/build_pdf.sh
+++ b/scripts/build_pdf.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+OUT_DIR="$ROOT_DIR/dist"
+mkdir -p "$OUT_DIR"
+pandoc "$ROOT_DIR/docs/whitepaper.md" -o "$OUT_DIR/Lemniscata_de_Penin.pdf"
+echo "Generated $OUT_DIR/Lemniscata_de_Penin.pdf"


### PR DESCRIPTION
## Summary
- Consolidate project details and module notes into `docs/whitepaper.md`.
- Introduce `scripts/build_pdf.sh` to build `dist/Lemniscata_de_Penin.pdf` via pandoc.
- Add `docs` target in `Makefile` to invoke the PDF build script.

## Testing
- `bash scripts/build_pdf.sh` *(fails: LaTeX package `xcolor.sty` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a69167a59c833386d63286b22ccda5